### PR TITLE
feat(site): fidelidade visual real ao projeto de referencia + melhorias

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="pt-br">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<link rel="icon" href="/img/avatar.png">
+<link href="/css/base.css" rel="stylesheet">
+<script>(function(){var t=localStorage.getItem("theme");if(t==="dark"||t==="light")document.documentElement.setAttribute("data-theme",t);})();</script>
+<title>Página não encontrada | Alan Nascimento</title>
+</head>
+<body>
+<header class="site-header">
+  <div class="container bar">
+    <a class="brand" href="/">eualannascimento.com</a>
+    <nav>
+      <a href="/bio.html">bio</a>
+      <a href="/certif.html">certif</a>
+      <a href="/setup.html">setup</a>
+      <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
+      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <div class="container home-hero">
+    <p class="home-eyebrow">Erro 404</p>
+    <h1 class="home-title" style="max-width: none;">Essa página não existe</h1>
+    <p class="home-subtitle">O endereço não foi encontrado. Volte para a home ou escolha uma das seções abaixo.</p>
+
+    <div class="nav-cards">
+      <a class="nav-card" href="/bio.html">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="nav-card-kicker">Trajetória</span>
+        <h2 class="nav-card-title">bio</h2>
+        <p class="nav-card-desc">De atendimento ao cliente a Engenheiro de Dados.</p>
+      </a>
+      <a class="nav-card" href="/certif.html">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="nav-card-kicker">Formação</span>
+        <h2 class="nav-card-title">certif*</h2>
+        <p class="nav-card-desc">Certificações e cursos concluídos.</p>
+      </a>
+      <a class="nav-card" href="/setup.html">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="nav-card-kicker">Bastidores</span>
+        <h2 class="nav-card-title">setup</h2>
+        <p class="nav-card-desc">Equipamentos e stack de software.</p>
+      </a>
+    </div>
+  </div>
+</main>
+<footer class="site-footer">
+  <div class="container">eualannascimento.com</div>
+</footer>
+<script src="/js/theme-toggle.js"></script>
+</body>
+</html>

--- a/bio.html
+++ b/bio.html
@@ -8,11 +8,14 @@
 <meta property="og:title" content="bio | Alan Nascimento">
 <meta property="og:description" content="Trajetória profissional de Alan Nascimento: 10 anos no Banco Bradesco, de atendimento ao cliente a Engenheiro de Dados.">
 <meta property="og:image" content="https://eualannascimento.com/img/me.png">
+<meta property="og:image:width" content="556">
+<meta property="og:image:height" content="556">
 <meta property="og:url" content="https://eualannascimento.com/bio.html">
 <meta name="twitter:card" content="summary">
 <link rel="canonical" href="https://eualannascimento.com/bio.html">
 <link rel="icon" href="/img/avatar.png">
 <link href="/css/base.css" rel="stylesheet">
+<script>(function(){var t=localStorage.getItem("theme");if(t==="dark"||t==="light")document.documentElement.setAttribute("data-theme",t);})();</script>
 <title>bio | Alan Nascimento</title>
 </head>
 <body>
@@ -20,17 +23,20 @@
   <div class="container bar">
     <a class="brand" href="/">eualannascimento.com</a>
     <nav>
-      <a href="/bio.html">bio</a>
+      <a href="/bio.html" class="active">bio</a>
       <a href="/certif.html">certif</a>
       <a href="/setup.html">setup</a>
       <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
       <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
 </header>
 <main>
   <div class="container">
     <article class="card">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+      <p class="section-title" style="margin-top: 0;">Trajetória</p>
       <h1>bio</h1>
       <p class="time">Atualizado em 20 de julho de 2026</p>
 
@@ -46,13 +52,13 @@
 
       <p>Tenho <strong>10 anos de experiência</strong> em ambiente corporativo/bancário no <strong>Banco Bradesco S.A.</strong> e mais de <strong>5 anos atuando com automações e análise de dados</strong>.</p>
 
-      <ul class="plain">
-        <li><strong>Comecei em 2014</strong>, trabalhando com <strong>atendimento ao cliente</strong>, com mais de 1 ano focado em serviços transacionais e reclamações, adquirindo profundo conhecimento dos produtos e serviços bancários brasileiros.</li>
-        <li>Posteriormente, <strong>em 2016</strong>, passei em uma vaga interna para atuar com <strong>gerenciamento de projetos</strong> nas áreas de SAC e Ouvidoria, focado em otimização de processos e eficiência operacional, lá desenvolvi minhas soft skills de análise, priorização, comunicação, delegação e negociação.</li>
-        <li>Após 3 anos, <strong>em 2019</strong>, com a decisão de atuar com desafios técnicos, obtive a oportunidade de migrar de setor e me tornei um analista de <strong>suporte técnico</strong> de Infraestrutura de TI, onde prestei suporte técnico a mais de 3000 estações de trabalho e otimizei o serviço de toda a equipe por meio de automações dos fluxos de trabalho.</li>
-        <li>Com esse background, <strong>a partir de 2021</strong>, trabalhei como <strong>analista de dados (business intelligence)</strong>, focado na criação de soluções colaborativas e geração de relatórios. Entreguei e mantive mais de 15 dashboards executivos em Power BI, além de uma solução em PowerApps que passou a atualização de relatórios de semanal para diária, economizando cerca de 1 semana de trabalho manual por mês para um grupo de aproximadamente 50 usuários. Também atuei como mentor técnico de estagiários.</li>
-        <li>Desde <strong>maio de 2025</strong>, migrei para a posição de <strong>Engenheiro de Dados (Data Engineer)</strong>, construindo e mantendo pipelines de dados e fluxos analíticos com Databricks (PySpark) e SQL, automatizando e padronizando rotinas de ETL/ELT e contribuindo para a governança de dados do time.</li>
-      </ul>
+      <ol class="timeline">
+        <li><span class="timeline-index">01</span><div><strong>Comecei em 2014</strong>, trabalhando com <strong>atendimento ao cliente</strong>, com mais de 1 ano focado em serviços transacionais e reclamações, adquirindo profundo conhecimento dos produtos e serviços bancários brasileiros.</div></li>
+        <li><span class="timeline-index">02</span><div>Posteriormente, <strong>em 2016</strong>, passei em uma vaga interna para atuar com <strong>gerenciamento de projetos</strong> nas áreas de SAC e Ouvidoria, focado em otimização de processos e eficiência operacional, lá desenvolvi minhas soft skills de análise, priorização, comunicação, delegação e negociação.</div></li>
+        <li><span class="timeline-index">03</span><div>Após 3 anos, <strong>em 2019</strong>, com a decisão de atuar com desafios técnicos, obtive a oportunidade de migrar de setor e me tornei um analista de <strong>suporte técnico</strong> de Infraestrutura de TI, onde prestei suporte técnico a mais de 3000 estações de trabalho e otimizei o serviço de toda a equipe por meio de automações dos fluxos de trabalho.</div></li>
+        <li><span class="timeline-index">04</span><div>Com esse background, <strong>a partir de 2021</strong>, trabalhei como <strong>analista de dados (business intelligence)</strong>, focado na criação de soluções colaborativas e geração de relatórios. Entreguei e mantive mais de 15 dashboards executivos em Power BI, além de uma solução em PowerApps que passou a atualização de relatórios de semanal para diária, economizando cerca de 1 semana de trabalho manual por mês para um grupo de aproximadamente 50 usuários. Também atuei como mentor técnico de estagiários.</div></li>
+        <li><span class="timeline-index">05</span><div>Desde <strong>maio de 2025</strong>, migrei para a posição de <strong>Engenheiro de Dados (Data Engineer)</strong>, construindo e mantendo pipelines de dados e fluxos analíticos com Databricks (PySpark) e SQL, automatizando e padronizando rotinas de ETL/ELT e contribuindo para a governança de dados do time.</div></li>
+      </ol>
 
       <p>Durante toda essa trajetória, também destaco minha colaboração com diversas equipes da empresa para melhorar a comunicação interna, implementar sugestões, criar apresentações para a Alta Liderança e otimizar recursos.</p>
 
@@ -61,11 +67,17 @@
       <p>Obrigado por passar por aqui 🌟<br>
       Vamos nos conectar? Me adicione no LinkedIn!<br>
       Forte abraço!</p>
+
+      <div class="resume-cta">
+        <p>Quer montar o seu currículo com o mesmo cuidado? Criei uma ferramenta gratuita para isso.</p>
+        <a class="btn btn-outline" href="https://github.com/eualannascimento/project-classificavagas-page-resume" target="_blank" rel="noopener noreferrer">Ver o projeto ↗</a>
+      </div>
     </article>
   </div>
 </main>
 <footer class="site-footer">
   <div class="container">eualannascimento.com</div>
 </footer>
+<script src="/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/certif.html
+++ b/certif.html
@@ -8,12 +8,15 @@
 <meta property="og:title" content="certif | Alan Nascimento">
 <meta property="og:description" content="Certificações e cursos de Alan Nascimento: 4x Microsoft Certified, Databricks, Notion e mais.">
 <meta property="og:image" content="https://eualannascimento.com/img/avatar.png">
+<meta property="og:image:width" content="556">
+<meta property="og:image:height" content="556">
 <meta property="og:url" content="https://eualannascimento.com/certif.html">
 <meta name="twitter:card" content="summary">
 <link rel="canonical" href="https://eualannascimento.com/certif.html">
 <link rel="icon" href="/img/avatar.png">
 <link href="/css/base.css" rel="stylesheet">
 <link href="/css/certif.css" rel="stylesheet">
+<script>(function(){var t=localStorage.getItem("theme");if(t==="dark"||t==="light")document.documentElement.setAttribute("data-theme",t);})();</script>
 <title>certif* | Alan Nascimento</title>
 </head>
 <body>
@@ -22,16 +25,19 @@
     <a class="brand" href="/">eualannascimento.com</a>
     <nav>
       <a href="/bio.html">bio</a>
-      <a href="/certif.html">certif</a>
+      <a href="/certif.html" class="active">certif</a>
       <a href="/setup.html">setup</a>
       <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
       <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
 </header>
 <main>
   <div class="container">
     <article class="card">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+      <p class="section-title" style="margin-top: 0;">Formação</p>
       <h1>certif*</h1>
       <p class="time">Atualizado em 20 de julho de 2026</p>
       <p>Página destinada a listar minhas certificações e meus cursos (com e sem certificado).<br>
@@ -51,6 +57,7 @@
 <footer class="site-footer">
   <div class="container">eualannascimento.com</div>
 </footer>
+<script src="/js/theme-toggle.js"></script>
 <script src="/js/certif-data.js"></script>
 <script src="/js/render.js"></script>
 <script>

--- a/css/base.css
+++ b/css/base.css
@@ -64,6 +64,7 @@
   --color-accent-100: #eef6ff;
   --color-accent-700: #416180;
   --color-accent-900: #1d2d3d;
+  --color-accent-emphasis: var(--color-accent-700);
 
   --font-heading: "Barlow Condensed", system-ui, sans-serif;
   --font-heading-weight: 600;
@@ -83,19 +84,32 @@
   --shadow-sm: 0 1px 2px color-mix(in srgb, #2b2b2d 14%, transparent);
   --shadow-md: 0 3px 10px color-mix(in srgb, #2b2b2d 16%, transparent);
 
-  --max-width: 720px;
+  --max-width: 760px;
+  --transition: 0.15s ease;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --color-bg: #16181a;
-    --color-surface: #1e2124;
-    --color-surface-2: #24272b;
-    --color-text: #f2f2f3;
-    --color-text-muted: #b7b7ba;
-    --color-divider: color-mix(in srgb, #f2f2f3 16%, transparent);
-    --color-accent-100: #1d2d3d;
-  }
+/* O projeto de referencia (project-classificavagas-page-resume) nao tem modo escuro:
+   o padrao aqui e sempre claro, igual a referencia. O escuro so existe se a pessoa
+   escolher manualmente pelo botao de tema (ver [data-theme] abaixo e js/theme-toggle.js). */
+:root[data-theme="dark"] {
+  --color-bg: #16181a;
+  --color-surface: #1e2124;
+  --color-surface-2: #24272b;
+  --color-text: #f2f2f3;
+  --color-text-muted: #b7b7ba;
+  --color-divider: color-mix(in srgb, #f2f2f3 16%, transparent);
+  --color-accent-100: #1d2d3d;
+  --color-accent-emphasis: var(--color-accent-2);
+}
+:root[data-theme="light"] {
+  --color-bg: #f2f2f3;
+  --color-surface: #e9e9ea;
+  --color-surface-2: #ffffff;
+  --color-text: #1d1f20;
+  --color-text-muted: #5d5d60;
+  --color-divider: color-mix(in srgb, #1d1f20 16%, transparent);
+  --color-accent-100: #eef6ff;
+  --color-accent-emphasis: var(--color-accent-700);
 }
 
 * , *::before, *::after { box-sizing: border-box; }
@@ -114,14 +128,26 @@ body {
 h1, h2, h3 {
   font-family: var(--font-heading);
   font-weight: var(--font-heading-weight);
-  line-height: 1.15;
+  line-height: 1.05;
+  letter-spacing: -0.01em;
   margin: 0 0 var(--space-3);
 }
 
-a { color: var(--color-accent-700); }
-@media (prefers-color-scheme: dark) {
-  a { color: var(--color-accent-2); }
+h1 {
+  font-size: clamp(1.9rem, 4vw, 2.5rem);
+  text-transform: uppercase;
 }
+
+.home-title {
+  font-size: clamp(2.4rem, 6vw, 3.5rem);
+  line-height: 1.04;
+  text-transform: uppercase;
+  margin: 0;
+  max-width: 16ch;
+}
+
+a { color: var(--color-accent-emphasis); text-underline-offset: 3px; }
+a:hover { color: var(--color-accent); }
 
 .container {
   max-width: var(--max-width);
@@ -129,29 +155,26 @@ a { color: var(--color-accent-700); }
   padding: 0 var(--space-4);
 }
 
-header.site-header {
-  background: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-}
-
+/* Header: barra simples sem fundo/borda, igual ao cv-nav da referencia. */
 header.site-header .bar {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  align-items: baseline;
   gap: var(--space-3);
   padding: var(--space-4) 0;
 }
 
 header.site-header .brand {
   font-family: var(--font-heading);
-  font-weight: 700;
-  font-size: 1.25rem;
+  font-weight: 600;
+  font-size: 1.3125rem;
+  letter-spacing: -0.01em;
   text-decoration: none;
   color: var(--color-text);
 }
 
 header.site-header nav {
+  margin-left: auto;
   display: flex;
   align-items: center;
   gap: var(--space-4);
@@ -159,47 +182,191 @@ header.site-header nav {
 
 header.site-header nav a {
   text-decoration: none;
-  color: var(--color-text);
-  font-weight: 500;
+  color: color-mix(in srgb, var(--color-text) 75%, transparent);
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: color var(--transition);
 }
 
-header.site-header nav a:hover { color: var(--color-accent-700); }
+header.site-header nav a:hover,
+header.site-header nav a.active { color: var(--color-accent-emphasis); }
 
-header.site-header nav .icon-link { font-size: 1.1rem; display: inline-flex; }
+header.site-header nav .icon-link { font-size: 0.75rem; display: inline-flex; }
+
+.theme-toggle {
+  background: transparent;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  width: 26px;
+  height: 26px;
+  font-size: 0.8125rem;
+  line-height: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color var(--transition), color var(--transition);
+}
+.theme-toggle:hover { border-color: var(--color-accent); color: var(--color-accent-emphasis); }
 
 main { padding: var(--space-8) 0; }
 
+/* Cartao "blueprint": cantos tecnicos, sem sombra, radius zero. */
 .card {
-  background: var(--color-surface-2);
+  position: relative;
+  background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  box-shadow: var(--shadow-sm);
+  border-radius: 0;
   padding: var(--space-6);
   margin-bottom: var(--space-6);
 }
 
+.corner {
+  position: absolute;
+  width: 5px;
+  height: 5px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-accent);
+  z-index: 2;
+}
+.corner.tl { top: -3px; left: -3px; }
+.corner.tr { top: -3px; right: -3px; }
+.corner.bl { bottom: -3px; left: -3px; }
+.corner.br { bottom: -3px; right: -3px; }
+
 .avatar {
-  width: 128px;
-  height: 128px;
+  width: 84px;
+  height: 84px;
   border-radius: 50%;
   object-fit: cover;
   display: block;
-  margin: 0 auto var(--space-4);
+  flex: none;
   box-shadow: var(--shadow-md);
 }
 
-.home-hero { text-align: center; }
-.home-hero p { color: var(--color-text-muted); }
+/* Botoes: radius zero, peso 600, sem caixa-alta forcada (igual aos .btn da referencia). */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.375rem;
+  padding: 0.5rem 1rem;
+  font-family: var(--font-heading);
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: 0;
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background var(--transition), border-color var(--transition), color var(--transition);
+  min-height: 38px;
+  white-space: nowrap;
+}
+.btn-primary { background: var(--color-accent); color: #fff; border-color: var(--color-accent); }
+.btn-primary:hover { background: var(--color-accent-700); border-color: var(--color-accent-700); color: #fff; }
+.btn-outline { background: transparent; color: var(--color-accent-emphasis); border-color: var(--color-accent); }
+.btn-outline:hover { background: var(--color-accent-100); color: var(--color-accent-emphasis); }
+
+.home-hero {
+  padding: var(--space-8) 0 var(--space-6);
+}
+
+.home-intro {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.home-subtitle {
+  font-size: 1.0625rem;
+  line-height: 1.55;
+  max-width: 56ch;
+  margin: var(--space-4) 0 0;
+  color: color-mix(in srgb, var(--color-text) 82%, transparent);
+}
+
+/* Eyebrow: badge em pilula, igual ao .home-eyebrow real da referencia. */
+.home-eyebrow {
+  display: inline-block;
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-accent-emphasis);
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-accent) 15%, transparent);
+  border-radius: 99px;
+  padding: 0.375rem 1rem;
+  margin: 0 0 var(--space-2);
+}
+
+.nav-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--space-4);
+  margin-top: var(--space-6);
+}
+
+.nav-card {
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color var(--transition);
+}
+.nav-card:hover { border-color: var(--color-accent); }
+
+.nav-card-kicker {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--color-text) 55%, transparent);
+}
+.nav-card-kicker-accent { color: var(--color-accent-emphasis); }
+
+.nav-card-title {
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 1.5rem;
+  text-transform: uppercase;
+  margin: 0.125rem 0 0;
+}
+
+.nav-card-desc {
+  font-size: 0.90625rem;
+  line-height: 1.55;
+  color: color-mix(in srgb, var(--color-text) 78%, transparent);
+  margin: 0;
+  flex: 1;
+}
+
+.nav-card .btn { margin-top: var(--space-2); align-self: flex-start; }
 
 .time { color: var(--color-text-muted); font-size: 0.875rem; margin-bottom: var(--space-4); }
 
 .section-title {
+  display: block;
   font-family: var(--font-heading);
   font-weight: 600;
-  font-size: 1.1rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
   margin: var(--space-6) 0 var(--space-2);
-  color: var(--color-accent-700);
+  color: var(--color-accent-emphasis);
 }
+.section-title:first-of-type { margin-top: var(--space-2); }
 
 ul.plain { list-style: none; padding: 0; margin: 0; }
 ul.plain li {
@@ -208,15 +375,78 @@ ul.plain li {
 }
 ul.plain li:last-child { border-bottom: none; }
 
+/* Chip para o badge de evidencia (formacao, certificado, link de credencial). */
+.badge-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-2);
+  font-size: 0.6875rem;
+  margin-right: var(--space-2);
+  flex: none;
+}
+
 .pending-badge {
   display: inline-block;
   font-size: 0.75rem;
   color: var(--color-text-muted);
 }
 
+/* Timeline numerada: usada quando o conteudo e realmente uma sequencia cronologica. */
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.timeline li {
+  display: flex;
+  gap: var(--space-4);
+  padding: var(--space-4) 0;
+  border-bottom: 1px solid var(--color-border);
+}
+.timeline li:last-child { border-bottom: none; }
+.timeline-index {
+  flex: none;
+  font-family: var(--font-heading);
+  font-weight: 700;
+  font-size: 1.5rem;
+  line-height: 1;
+  color: var(--color-accent-emphasis);
+  opacity: 0.55;
+  min-width: 2ch;
+}
+
+/* CTA discreto de referencia cruzada com a ferramenta de curriculo. */
+.resume-cta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  margin-top: var(--space-6);
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--color-border);
+}
+.resume-cta p {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+  max-width: 44ch;
+}
+
 footer.site-footer {
   text-align: center;
   padding: var(--space-6) 0;
   color: var(--color-text-muted);
-  font-size: 0.875rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  border-top: 1px solid var(--color-border);
+}
+
+@media (max-width: 620px) {
+  .nav-cards { grid-template-columns: 1fr; }
+  header.site-header nav { gap: var(--space-3); }
 }

--- a/css/certif.css
+++ b/css/certif.css
@@ -1,2 +1,1 @@
 /* ajustes especificos da pagina certif */
-.section-title:first-of-type { margin-top: var(--space-2); }

--- a/index.html
+++ b/index.html
@@ -8,11 +8,14 @@
 <meta property="og:title" content="Alan Nascimento">
 <meta property="og:description" content="Engenheiro de Dados no Bradesco, especialista em Power BI, Databricks e automação de dados.">
 <meta property="og:image" content="https://eualannascimento.com/img/avatar.png">
+<meta property="og:image:width" content="556">
+<meta property="og:image:height" content="556">
 <meta property="og:url" content="https://eualannascimento.com/">
 <meta name="twitter:card" content="summary">
 <link rel="canonical" href="https://eualannascimento.com/">
 <link rel="icon" href="/img/avatar.png">
 <link href="/css/base.css" rel="stylesheet">
+<script>(function(){var t=localStorage.getItem("theme");if(t==="dark"||t==="light")document.documentElement.setAttribute("data-theme",t);})();</script>
 <title>Alan Nascimento</title>
 </head>
 <body>
@@ -25,18 +28,54 @@
       <a href="/setup.html">setup</a>
       <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
       <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
 </header>
 <main>
   <div class="container home-hero">
-    <img class="avatar" src="/img/avatar.png" alt="Foto de Alan Nascimento">
-    <h1>Alan Nascimento</h1>
-    <p>Engenheiro de Dados no Bradesco | site pessoal e portfólio</p>
+    <div class="home-intro">
+      <img class="avatar" src="/img/avatar.png" alt="Foto de Alan Nascimento">
+      <div>
+        <p class="home-eyebrow">Site pessoal e portfólio</p>
+        <h1 class="home-title">Alan Nascimento</h1>
+      </div>
+    </div>
+    <p class="home-subtitle">Engenheiro de Dados no Bradesco, com trajetória em BI, automação e governança de dados.</p>
+
+    <div class="nav-cards">
+      <a class="nav-card" href="/bio.html">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="nav-card-kicker nav-card-kicker-accent">Trajetória</span>
+        <h2 class="nav-card-title">bio</h2>
+        <p class="nav-card-desc">De atendimento ao cliente a Engenheiro de Dados: os 10 anos de carreira no Bradesco.</p>
+        <span class="btn btn-primary">Ler a bio</span>
+      </a>
+      <a class="nav-card" href="/certif.html">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="nav-card-kicker">Formação</span>
+        <h2 class="nav-card-title">certif*</h2>
+        <p class="nav-card-desc">Certificações Microsoft, cursos concluídos e em andamento desde 2012.</p>
+        <span class="btn btn-outline">Ver certificações</span>
+      </a>
+      <a class="nav-card" href="/setup.html">
+        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+        <span class="nav-card-kicker">Bastidores</span>
+        <h2 class="nav-card-title">setup</h2>
+        <p class="nav-card-desc">Equipamentos e stack de software usados no dia a dia.</p>
+        <span class="btn btn-outline">Ver setup</span>
+      </a>
+    </div>
+
+    <div class="resume-cta">
+      <p>Também criei uma ferramenta gratuita para gerar currículo e guia de LinkedIn, sem cadastro e 100% no navegador.</p>
+      <a class="btn btn-outline" href="https://github.com/eualannascimento/project-classificavagas-page-resume" target="_blank" rel="noopener noreferrer">Ver o projeto ↗</a>
+    </div>
   </div>
 </main>
 <footer class="site-footer">
   <div class="container">eualannascimento.com</div>
 </footer>
+<script src="/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/js/render.js
+++ b/js/render.js
@@ -13,7 +13,7 @@ const SiteRender = (function () {
 
   function renderEntry(item) {
     const parts = [];
-    if (item.badge) parts.push(escapeHtml(item.badge) + " ");
+    if (item.badge) parts.push('<span class="badge-chip">' + escapeHtml(item.badge) + "</span>");
     if (item.date) parts.push("<strong>" + escapeHtml(item.date) + "</strong>: ");
     parts.push(escapeHtml(item.text));
     if (item.evidence) {

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,44 @@
+/* Alternancia manual de tema (padrao segue o sistema; escolha fica em localStorage). */
+(function () {
+  "use strict";
+
+  const STORAGE_KEY = "theme";
+  const root = document.documentElement;
+
+  function systemPrefersDark() {
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+  }
+
+  function apply(theme) {
+    if (theme === "dark" || theme === "light") {
+      root.setAttribute("data-theme", theme);
+    } else {
+      root.removeAttribute("data-theme");
+    }
+    const btn = document.getElementById("theme-toggle");
+    if (btn) {
+      const isDark = theme === "dark" || (theme !== "light" && systemPrefersDark());
+      btn.textContent = isDark ? "☀" : "☾";
+      btn.setAttribute("aria-label", isDark ? "Mudar para tema claro" : "Mudar para tema escuro");
+    }
+  }
+
+  function init() {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    apply(stored);
+    const btn = document.getElementById("theme-toggle");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      const current = localStorage.getItem(STORAGE_KEY) || (systemPrefersDark() ? "dark" : "light");
+      const next = current === "dark" ? "light" : "dark";
+      localStorage.setItem(STORAGE_KEY, next);
+      apply(next);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://eualannascimento.com/sitemap.xml

--- a/setup.html
+++ b/setup.html
@@ -8,11 +8,14 @@
 <meta property="og:title" content="setup | Alan Nascimento">
 <meta property="og:description" content="Equipamentos e stack de software usados no dia a dia por Alan Nascimento.">
 <meta property="og:image" content="https://eualannascimento.com/img/avatar.png">
+<meta property="og:image:width" content="556">
+<meta property="og:image:height" content="556">
 <meta property="og:url" content="https://eualannascimento.com/setup.html">
 <meta name="twitter:card" content="summary">
 <link rel="canonical" href="https://eualannascimento.com/setup.html">
 <link rel="icon" href="/img/avatar.png">
 <link href="/css/base.css" rel="stylesheet">
+<script>(function(){var t=localStorage.getItem("theme");if(t==="dark"||t==="light")document.documentElement.setAttribute("data-theme",t);})();</script>
 <title>setup | Alan Nascimento</title>
 </head>
 <body>
@@ -22,15 +25,18 @@
     <nav>
       <a href="/bio.html">bio</a>
       <a href="/certif.html">certif</a>
-      <a href="/setup.html">setup</a>
+      <a href="/setup.html" class="active">setup</a>
       <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
       <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
 </header>
 <main>
   <div class="container">
     <article class="card">
+      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
+      <p class="section-title" style="margin-top: 0;">Bastidores</p>
       <h1>setup</h1>
       <p class="time">Espaço separado para listar meu setup e minha stack atuais.</p>
 
@@ -45,6 +51,7 @@
 <footer class="site-footer">
   <div class="container">eualannascimento.com</div>
 </footer>
+<script src="/js/theme-toggle.js"></script>
 <script src="/js/setup-data.js"></script>
 <script src="/js/render.js"></script>
 <script>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://eualannascimento.com/</loc>
+  </url>
+  <url>
+    <loc>https://eualannascimento.com/bio.html</loc>
+  </url>
+  <url>
+    <loc>https://eualannascimento.com/certif.html</loc>
+  </url>
+  <url>
+    <loc>https://eualannascimento.com/setup.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## Resumo
- Reconstroi o design para copiar de fato a linguagem visual do project-classificavagas-page-resume (cantos blueprint, header transparente, hero alinhado a esquerda, eyebrow em pilula, tema sempre claro por padrao), conferida com getComputedStyle na pagina de referencia rodando, nao so lendo o CSS fonte.
- Home reformulada com cards de navegacao reais (kicker, titulo, descricao, botao).
- Bio ganha timeline numerada (01-05) para o historico de carreira, por ser uma sequencia cronologica real.
- Alternancia manual de tema (claro/escuro) persistida em localStorage.
- Chips visuais para os badges de certificacao, estado ativo na navegacao, CTA cruzado para a ferramenta de curriculo.
- SEO: pagina 404, robots.txt, sitemap.xml, og:image:width/height.

## Plano de teste
- [x] Validado nas 4 paginas + 404 no navegador local (claro e escuro)
- [x] Nenhum fato de bio/certif/setup removido (regra de ouro do spec redesign-site-pessoal)
- [x] Sem travessao introduzido (grep limpo)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)