### PR TITLE
fix(ci): conserta gate forbidden-chars pre-existente

### DIFF
--- a/.docs/pendencias-certificados.md
+++ b/.docs/pendencias-certificados.md
@@ -7,4 +7,4 @@ Nenhuma pendência no momento: as 8 certificações novas trazidas do LinkedIn e
 ## Como usar
 Ao adicionar uma certificação/curso sem nenhuma evidência disponível, registre aqui:
 
-- [ ] Nome do curso/certificação — instituição — data — o que falta (print do certificado, link de verificação, etc.)
+- [ ] Nome do curso/certificação - instituição - data - o que falta (print do certificado, link de verificação, etc.)

--- a/.github/workflows/style-gate.yml
+++ b/.github/workflows/style-gate.yml
@@ -3,6 +3,9 @@
 # meia-risca (U+2013) ou aspas curvas (U+201C/U+201D).
 # Apenas caracteres sao verificados aqui: sao deterministicos e sem falso
 # positivo. O vocabulario (E04/E05) continua como instrucao para a IA.
+# Excecoes: arquivos binarios (-I) e os specs baseline-*.md/architecture.md,
+# que a spec redesign-site-pessoal.md proibe reescrever (registro historico
+# do estado pre-redesign).
 name: style-gate
 on:
   push:
@@ -15,7 +18,11 @@ jobs:
       - name: Bloquear travessao, meia-risca e aspas curvas
         run: |
           pat=$(printf '\xe2\x80\x94|\xe2\x80\x93|\xe2\x80\x9c|\xe2\x80\x9d')
-          if grep -rnE "$pat" --exclude-dir=.git .; then
+          if grep -rnIE "$pat" \
+              --exclude-dir=.git \
+              --exclude='baseline-*.md' \
+              --exclude='architecture.md' \
+              .; then
             echo "Caracteres proibidos encontrados. Substitua por hifen e aspas retas (ver .rules/anti-ai-style.md, E01 e E02)."
             exit 1
           fi

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -159,7 +159,7 @@ assert(exists('CNAME') && read('CNAME').trim() === 'eualannascimento.com', 'CNAM
 
 // --- Estilo anti-IA: sem travessao ---
 console.log('\nTextos sem travessao:');
-const withDash = pages.filter((p) => /—|–/.test(read(p)));
+const withDash = pages.filter((p) => /\u2014|\u2013/.test(read(p)));
 assert(withDash.length === 0, `Nenhum travessao nas paginas HTML${withDash.length ? ' (falha: ' + withDash.join(', ') + ')' : ''}`);
 
 // --- Summary ---


### PR DESCRIPTION
## Resumo
O gate `forbidden-chars` ja falhava na main antes do PR #3, sem relacao com o conteudo daquele PR:
- Binarios (PNG) cujos bytes coincidem com a sequencia UTF-8 do travessao
- `.docs/architecture.md` e `.docs/specs/baseline-*.md`, que `redesign-site-pessoal.md` proibe reescrever (registro historico)
- `tests/smoke-test.js` continha os proprios caracteres proibidos dentro da regex que os detecta

## Mudancas
- Workflow: `-I` (ignora binarios) e `--exclude` para os specs baseline preservados
- `smoke-test.js`: regex trocada para escapes unicode, mesma deteccao sem se autodisparar
- `pendencias-certificados.md`: unica ocorrencia real fora do escopo historico, corrigida para hifen

## Plano de teste
- [x] `node tests/smoke-test.js` (114 passou, 0 falhou)
- [x] grep local do gate limpo

🤖 Gerado com [Claude Code](https://claude.com/claude-code)