### PR TITLE
feat(site): refina experiencia para recrutador/gestor

### DIFF
--- a/404.html
+++ b/404.html
@@ -18,7 +18,7 @@
       <a href="/certif.html">certif</a>
       <a href="/setup.html">setup</a>
       <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>

--- a/bio.html
+++ b/bio.html
@@ -27,7 +27,7 @@
       <a href="/certif.html">certif</a>
       <a href="/setup.html">setup</a>
       <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>

--- a/certif.html
+++ b/certif.html
@@ -28,7 +28,7 @@
       <a href="/certif.html" class="active">certif</a>
       <a href="/setup.html">setup</a>
       <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>

--- a/css/base.css
+++ b/css/base.css
@@ -199,6 +199,15 @@ header.site-header nav a.active { color: var(--color-accent-emphasis); }
 
 header.site-header nav .icon-link { font-size: 0.75rem; }
 
+/* LinkedIn e o destino que mais importa para quem recruta: ganha um contorno
+   proprio para se destacar dos links de navegacao interna. */
+header.site-header nav a.nav-link-highlight {
+  padding: 0.3125rem 0.75rem;
+  border: 1px solid var(--color-accent);
+  color: var(--color-accent-emphasis);
+}
+header.site-header nav a.nav-link-highlight:hover { background: var(--color-accent-100); }
+
 .theme-toggle {
   background: transparent;
   border: 1px solid var(--color-border);
@@ -217,6 +226,15 @@ header.site-header nav .icon-link { font-size: 0.75rem; }
 .theme-toggle:hover { border-color: var(--color-accent); color: var(--color-accent-emphasis); }
 
 main { padding: var(--space-8) 0; }
+
+/* Entrada suave da pagina, igual ao cvfade da referencia. Respeita reduced-motion. */
+@keyframes site-fade-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: none; }
+}
+@media (prefers-reduced-motion: no-preference) {
+  main { animation: site-fade-in 0.4s ease; }
+}
 
 /* Cartao "blueprint": cantos tecnicos, sem sombra, radius zero. */
 .card {
@@ -309,6 +327,32 @@ main { padding: var(--space-8) 0; }
   margin: 0 0 var(--space-2);
 }
 
+/* Leitura rapida: experiencia + stack, para quem tem 10 segundos antes de decidir continuar. */
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: var(--space-4) 0 0;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 0.8125rem;
+  letter-spacing: 0.01em;
+  padding: 0.3125rem 0.75rem;
+  border: 1px solid var(--color-border);
+  color: color-mix(in srgb, var(--color-text) 80%, transparent);
+}
+
+.tag-strong {
+  border-color: var(--color-accent);
+  color: var(--color-accent-emphasis);
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+}
+
 .nav-cards {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -326,9 +370,9 @@ main { padding: var(--space-8) 0; }
   gap: var(--space-2);
   text-decoration: none;
   color: inherit;
-  transition: border-color var(--transition);
+  transition: border-color var(--transition), transform var(--transition);
 }
-.nav-card:hover { border-color: var(--color-accent); }
+.nav-card:hover { border-color: var(--color-accent); transform: translateY(-2px); }
 
 .nav-card-kicker {
   font-family: var(--font-heading);

--- a/css/base.css
+++ b/css/base.css
@@ -181,6 +181,9 @@ header.site-header nav {
 }
 
 header.site-header nav a {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-3) 0;
   text-decoration: none;
   color: color-mix(in srgb, var(--color-text) 75%, transparent);
   font-family: var(--font-heading);
@@ -194,14 +197,15 @@ header.site-header nav a {
 header.site-header nav a:hover,
 header.site-header nav a.active { color: var(--color-accent-emphasis); }
 
-header.site-header nav .icon-link { font-size: 0.75rem; display: inline-flex; }
+header.site-header nav .icon-link { font-size: 0.75rem; }
 
 .theme-toggle {
   background: transparent;
   border: 1px solid var(--color-border);
   color: var(--color-text);
-  width: 26px;
-  height: 26px;
+  width: 30px;
+  height: 30px;
+  flex: none;
   font-size: 0.8125rem;
   line-height: 1;
   cursor: pointer;
@@ -448,5 +452,24 @@ footer.site-footer {
 
 @media (max-width: 620px) {
   .nav-cards { grid-template-columns: 1fr; }
-  header.site-header nav { gap: var(--space-3); }
+
+  /* Header: duas linhas deliberadas (marca, depois nav) em vez de um wrap
+     organico que sobra encostado na borda direita. */
+  header.site-header .bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-3);
+    padding: var(--space-3) 0;
+  }
+  header.site-header nav {
+    margin-left: 0;
+    width: 100%;
+    flex-wrap: wrap;
+    row-gap: var(--space-2);
+    column-gap: var(--space-4);
+  }
+
+  /* Alvos de toque de pelo menos 44px, sem aumentar o peso visual do texto. */
+  .theme-toggle { width: 36px; height: 36px; margin-left: auto; }
+  .btn { min-height: 44px; }
 }

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <a href="/certif.html">certif</a>
       <a href="/setup.html">setup</a>
       <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
@@ -42,6 +42,15 @@
       </div>
     </div>
     <p class="home-subtitle">Engenheiro de Dados no Bradesco, com trajetória em BI, automação e governança de dados.</p>
+
+    <div class="tag-row">
+      <span class="tag tag-strong">10 anos de experiência</span>
+      <span class="tag">Databricks (PySpark)</span>
+      <span class="tag">Power BI</span>
+      <span class="tag">SQL</span>
+      <span class="tag">Azure</span>
+      <span class="tag">Power Platform</span>
+    </div>
 
     <div class="nav-cards">
       <a class="nav-card" href="/bio.html">

--- a/setup.html
+++ b/setup.html
@@ -27,7 +27,7 @@
       <a href="/certif.html">certif</a>
       <a href="/setup.html" class="active">setup</a>
       <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>


### PR DESCRIPTION
## Resumo
Refinamento pensando em quem chega no site avaliando o candidato (recrutador ou gestor de contratacao), com foco em atratividade e elegancia sem abandonar a identidade visual "blueprint" ja estabelecida.

## Mudancas
- **Leitura rapida**: tags de experiencia (10 anos) + stack (Databricks, Power BI, SQL, Azure, Power Platform) logo abaixo do subtitulo da home. Antes, era preciso entrar na bio para descobrir isso.
- **LinkedIn em destaque**: o link ganha contorno proprio no header (`.nav-link-highlight`) em todas as 5 paginas, separando-o visualmente da navegacao interna do site, ja que e o destino que mais importa para quem recruta.
- **Polimento**: hover com leve elevacao nos cards de navegacao, e a entrada suave de pagina (`site-fade-in`) que a referencia ja tinha (`cvfade`) e que eu nao tinha portado ainda. Respeita `prefers-reduced-motion`.

## Plano de teste
- [x] Validado em claro e escuro, desktop e frame mobile de 320px (sem overflow)
- [x] Hover/lift testado interativamente
- [x] `node tests/smoke-test.js` (114 passou, 0 falhou)

🤖 Gerado com [Claude Code](https://claude.com/claude-code)