### PR TITLE
fix(css): corrige colisao de padding que zerava o gutter lateral

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -161,7 +161,8 @@ header.site-header .bar {
   flex-wrap: wrap;
   align-items: baseline;
   gap: var(--space-3);
-  padding: var(--space-4) 0;
+  padding-top: var(--space-4);
+  padding-bottom: var(--space-4);
 }
 
 header.site-header .brand {
@@ -293,7 +294,8 @@ main { padding: var(--space-8) 0; }
 .btn-outline:hover { background: var(--color-accent-100); color: var(--color-accent-emphasis); }
 
 .home-hero {
-  padding: var(--space-8) 0 var(--space-6);
+  padding-top: var(--space-8);
+  padding-bottom: var(--space-6);
 }
 
 .home-intro {
@@ -503,7 +505,8 @@ footer.site-footer {
     flex-direction: column;
     align-items: flex-start;
     gap: var(--space-3);
-    padding: var(--space-3) 0;
+    padding-top: var(--space-3);
+    padding-bottom: var(--space-3);
   }
   header.site-header nav {
     margin-left: 0;


### PR DESCRIPTION
## Resumo
- header.site-header .bar e .home-hero usavam o shorthand padding, que sobrescrevia por completo o padding: 0 var(--space-4) do .container (mesmo elemento tem as duas classes em todas as paginas), zerando o padding esquerdo/direito.
- Isso deixava o header e o hero da home sem margem lateral nenhuma no mobile (e no desktop tambem, mascarado pelo max-width centralizado).
- Trocado padding shorthand por padding-top/padding-bottom nos tres pontos afetados (regra base do .bar, .home-hero e a media query de 620px do .bar).

## Test plan
- [x] Testado em viewport de ~375-400px: padding-left/right do .bar e .home-hero voltam a 16px
- [x] Nenhuma mudanca visual no desktop (max-width ja centralizava o conteudo)