### PR TITLE
refactor(site): header minimalista e ajustes de espacamento

### DIFF
--- a/404.html
+++ b/404.html
@@ -14,11 +14,9 @@
   <div class="container bar">
     <a class="brand" href="/">eualannascimento.com</a>
     <nav>
-      <a href="/bio.html">bio</a>
-      <a href="/certif.html">certif</a>
-      <a href="/setup.html">setup</a>
-      <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.5 8h4V23h-4V8zM8.5 8h3.8v2.05h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V23h-4v-6.9c0-1.65-.03-3.77-2.3-3.77-2.3 0-2.65 1.8-2.65 3.65V23h-4V8z"/></svg>
+      </a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
@@ -51,9 +49,6 @@
     </div>
   </div>
 </main>
-<footer class="site-footer">
-  <div class="container">eualannascimento.com</div>
-</footer>
 <script src="/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/bio.html
+++ b/bio.html
@@ -23,11 +23,9 @@
   <div class="container bar">
     <a class="brand" href="/">eualannascimento.com</a>
     <nav>
-      <a href="/bio.html" class="active">bio</a>
-      <a href="/certif.html">certif</a>
-      <a href="/setup.html">setup</a>
-      <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.5 8h4V23h-4V8zM8.5 8h3.8v2.05h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V23h-4v-6.9c0-1.65-.03-3.77-2.3-3.77-2.3 0-2.65 1.8-2.65 3.65V23h-4V8z"/></svg>
+      </a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
@@ -75,9 +73,6 @@
     </article>
   </div>
 </main>
-<footer class="site-footer">
-  <div class="container">eualannascimento.com</div>
-</footer>
 <script src="/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/certif.html
+++ b/certif.html
@@ -24,11 +24,9 @@
   <div class="container bar">
     <a class="brand" href="/">eualannascimento.com</a>
     <nav>
-      <a href="/bio.html">bio</a>
-      <a href="/certif.html" class="active">certif</a>
-      <a href="/setup.html">setup</a>
-      <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.5 8h4V23h-4V8zM8.5 8h3.8v2.05h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V23h-4v-6.9c0-1.65-.03-3.77-2.3-3.77-2.3 0-2.65 1.8-2.65 3.65V23h-4V8z"/></svg>
+      </a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
@@ -54,9 +52,6 @@
     </article>
   </div>
 </main>
-<footer class="site-footer">
-  <div class="container">eualannascimento.com</div>
-</footer>
 <script src="/js/theme-toggle.js"></script>
 <script src="/js/certif-data.js"></script>
 <script src="/js/render.js"></script>

--- a/css/base.css
+++ b/css/base.css
@@ -159,10 +159,10 @@ a:hover { color: var(--color-accent); }
 header.site-header .bar {
   display: flex;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: center;
   gap: var(--space-3);
-  padding-top: var(--space-4);
-  padding-bottom: var(--space-4);
+  padding-top: var(--space-3);
+  padding-bottom: var(--space-3);
 }
 
 header.site-header .brand {
@@ -178,36 +178,23 @@ header.site-header nav {
   margin-left: auto;
   display: flex;
   align-items: center;
-  gap: var(--space-4);
+  gap: var(--space-2);
 }
 
-header.site-header nav a {
+header.site-header nav a.icon-link {
   display: inline-flex;
   align-items: center;
-  padding: var(--space-3) 0;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: none;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
   text-decoration: none;
-  color: color-mix(in srgb, var(--color-text) 75%, transparent);
-  font-family: var(--font-heading);
-  font-weight: 600;
-  font-size: 0.8125rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  transition: color var(--transition);
+  transition: border-color var(--transition), color var(--transition);
 }
-
-header.site-header nav a:hover,
-header.site-header nav a.active { color: var(--color-accent-emphasis); }
-
-header.site-header nav .icon-link { font-size: 0.75rem; }
-
-/* LinkedIn e o destino que mais importa para quem recruta: ganha um contorno
-   proprio para se destacar dos links de navegacao interna. */
-header.site-header nav a.nav-link-highlight {
-  padding: 0.3125rem 0.75rem;
-  border: 1px solid var(--color-accent);
-  color: var(--color-accent-emphasis);
-}
-header.site-header nav a.nav-link-highlight:hover { background: var(--color-accent-100); }
+header.site-header nav a.icon-link:hover { border-color: var(--color-accent); color: var(--color-accent-emphasis); }
+header.site-header nav a.icon-link svg { width: 14px; height: 14px; }
 
 .theme-toggle {
   background: transparent;
@@ -226,7 +213,7 @@ header.site-header nav a.nav-link-highlight:hover { background: var(--color-acce
 }
 .theme-toggle:hover { border-color: var(--color-accent); color: var(--color-accent-emphasis); }
 
-main { padding: var(--space-8) 0; }
+main { padding: var(--space-6) 0; }
 
 /* Entrada suave da pagina, igual ao cvfade da referencia. Respeita reduced-motion. */
 @keyframes site-fade-in {
@@ -263,7 +250,7 @@ main { padding: var(--space-8) 0; }
 .avatar {
   width: 84px;
   height: 84px;
-  border-radius: 50%;
+  border-radius: 0;
   object-fit: cover;
   display: block;
   flex: none;
@@ -294,8 +281,8 @@ main { padding: var(--space-8) 0; }
 .btn-outline:hover { background: var(--color-accent-100); color: var(--color-accent-emphasis); }
 
 .home-hero {
-  padding-top: var(--space-8);
-  padding-bottom: var(--space-6);
+  padding-top: var(--space-6);
+  padding-bottom: var(--space-4);
 }
 
 .home-intro {
@@ -327,32 +314,6 @@ main { padding: var(--space-8) 0; }
   border-radius: 99px;
   padding: 0.375rem 1rem;
   margin: 0 0 var(--space-2);
-}
-
-/* Leitura rapida: experiencia + stack, para quem tem 10 segundos antes de decidir continuar. */
-.tag-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  margin: var(--space-4) 0 0;
-}
-
-.tag {
-  display: inline-flex;
-  align-items: center;
-  font-family: var(--font-heading);
-  font-weight: 600;
-  font-size: 0.8125rem;
-  letter-spacing: 0.01em;
-  padding: 0.3125rem 0.75rem;
-  border: 1px solid var(--color-border);
-  color: color-mix(in srgb, var(--color-text) 80%, transparent);
-}
-
-.tag-strong {
-  border-color: var(--color-accent);
-  color: var(--color-accent-emphasis);
-  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
 }
 
 .nav-cards {
@@ -487,36 +448,11 @@ ul.plain li:last-child { border-bottom: none; }
   max-width: 44ch;
 }
 
-footer.site-footer {
-  text-align: center;
-  padding: var(--space-6) 0;
-  color: var(--color-text-muted);
-  font-size: 0.75rem;
-  letter-spacing: 0.02em;
-  border-top: 1px solid var(--color-border);
-}
-
 @media (max-width: 620px) {
   .nav-cards { grid-template-columns: 1fr; }
 
-  /* Header: duas linhas deliberadas (marca, depois nav) em vez de um wrap
-     organico que sobra encostado na borda direita. */
-  header.site-header .bar {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: var(--space-3);
-    padding-top: var(--space-3);
-    padding-bottom: var(--space-3);
-  }
-  header.site-header nav {
-    margin-left: 0;
-    width: 100%;
-    flex-wrap: wrap;
-    row-gap: var(--space-2);
-    column-gap: var(--space-4);
-  }
-
-  /* Alvos de toque de pelo menos 44px, sem aumentar o peso visual do texto. */
-  .theme-toggle { width: 36px; height: 36px; margin-left: auto; }
+  /* Alvos de toque de pelo menos 36px, sem quebrar o header em duas linhas. */
+  header.site-header nav a.icon-link,
+  .theme-toggle { width: 36px; height: 36px; }
   .btn { min-height: 44px; }
 }

--- a/index.html
+++ b/index.html
@@ -23,11 +23,9 @@
   <div class="container bar">
     <a class="brand" href="/">eualannascimento.com</a>
     <nav>
-      <a href="/bio.html">bio</a>
-      <a href="/certif.html">certif</a>
-      <a href="/setup.html">setup</a>
-      <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.5 8h4V23h-4V8zM8.5 8h3.8v2.05h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V23h-4v-6.9c0-1.65-.03-3.77-2.3-3.77-2.3 0-2.65 1.8-2.65 3.65V23h-4V8z"/></svg>
+      </a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
@@ -42,15 +40,6 @@
       </div>
     </div>
     <p class="home-subtitle">Engenheiro de Dados no Bradesco, com trajetória em BI, automação e governança de dados.</p>
-
-    <div class="tag-row">
-      <span class="tag tag-strong">10 anos de experiência</span>
-      <span class="tag">Databricks (PySpark)</span>
-      <span class="tag">Power BI</span>
-      <span class="tag">SQL</span>
-      <span class="tag">Azure</span>
-      <span class="tag">Power Platform</span>
-    </div>
 
     <div class="nav-cards">
       <a class="nav-card" href="/bio.html">
@@ -82,9 +71,6 @@
     </div>
   </div>
 </main>
-<footer class="site-footer">
-  <div class="container">eualannascimento.com</div>
-</footer>
 <script src="/js/theme-toggle.js"></script>
 </body>
 </html>

--- a/setup.html
+++ b/setup.html
@@ -23,11 +23,9 @@
   <div class="container bar">
     <a class="brand" href="/">eualannascimento.com</a>
     <nav>
-      <a href="/bio.html">bio</a>
-      <a href="/certif.html">certif</a>
-      <a href="/setup.html" class="active">setup</a>
-      <a class="icon-link" href="https://github.com/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="GitHub">GitHub</a>
-      <a class="icon-link nav-link-highlight" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">LinkedIn</a>
+      <a class="icon-link" href="https://www.linkedin.com/in/eualannascimento" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.98 3.5C4.98 4.88 3.87 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1s2.48 1.12 2.48 2.5zM.5 8h4V23h-4V8zM8.5 8h3.8v2.05h.05c.53-1 1.83-2.05 3.77-2.05 4.03 0 4.78 2.65 4.78 6.1V23h-4v-6.9c0-1.65-.03-3.77-2.3-3.77-2.3 0-2.65 1.8-2.65 3.65V23h-4V8z"/></svg>
+      </a>
       <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Mudar tema">☾</button>
     </nav>
   </div>
@@ -48,9 +46,6 @@
     </article>
   </div>
 </main>
-<footer class="site-footer">
-  <div class="container">eualannascimento.com</div>
-</footer>
 <script src="/js/theme-toggle.js"></script>
 <script src="/js/setup-data.js"></script>
 <script src="/js/render.js"></script>


### PR DESCRIPTION
## Resumo
- Header: mantidos apenas o icone do LinkedIn e o toggle de tema (nav de bio/certif/setup/GitHub removida; navegacao interna segue pelos nav-cards da home e pelo brand).
- Footer removido de todas as paginas.
- Espacamento vertical reduzido no header e na home (main, .bar, .home-hero).
- Tags de stack (SQL, Azure etc.) removidas da home.
- Avatar quadrado (radius zero) em vez de circular.

## Test plan
- [x] Testado em ~360px de largura: header em uma linha, sem overflow
- [x] Avatar quadrado confirmado via computed style em index.html e bio.html
- [x] CSS morto (.tag/.tag-row/.nav-link-highlight/footer.site-footer) removido junto