### PR TITLE
refactor(site): remove foto e reduz ornamentos para visual mais discreto

### DIFF
--- a/404.html
+++ b/404.html
@@ -28,21 +28,15 @@
     <p class="home-subtitle">O endereço não foi encontrado. Volte para a home ou escolha uma das seções abaixo.</p>
 
     <div class="nav-cards">
-      <a class="nav-card" href="/bio.html">
-        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
-        <span class="nav-card-kicker">Trajetória</span>
+      <a class="nav-card" href="/bio.html">        <span class="nav-card-kicker">Trajetória</span>
         <h2 class="nav-card-title">bio</h2>
         <p class="nav-card-desc">De atendimento ao cliente a Engenheiro de Dados.</p>
       </a>
-      <a class="nav-card" href="/certif.html">
-        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
-        <span class="nav-card-kicker">Formação</span>
+      <a class="nav-card" href="/certif.html">        <span class="nav-card-kicker">Formação</span>
         <h2 class="nav-card-title">certif*</h2>
         <p class="nav-card-desc">Certificações e cursos concluídos.</p>
       </a>
-      <a class="nav-card" href="/setup.html">
-        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
-        <span class="nav-card-kicker">Bastidores</span>
+      <a class="nav-card" href="/setup.html">        <span class="nav-card-kicker">Bastidores</span>
         <h2 class="nav-card-title">setup</h2>
         <p class="nav-card-desc">Equipamentos e stack de software.</p>
       </a>

--- a/bio.html
+++ b/bio.html
@@ -32,16 +32,12 @@
 </header>
 <main>
   <div class="container">
-    <article class="card">
-      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
-      <p class="section-title" style="margin-top: 0;">Trajetória</p>
+    <article class="card">      <p class="section-title" style="margin-top: 0;">Trajetória</p>
       <h1>bio</h1>
       <p class="time">Atualizado em 20 de julho de 2026</p>
 
       <p>Bem-vindo a minha bio.<br>
       Sou um profissional versátil, com uma grande paixão (clichê) no âmbito profissional: <strong>gerar soluções!</strong></p>
-
-      <img class="avatar" src="/img/me.png" alt="Foto de Alan Nascimento">
 
       <p>Apaixonado por tecnologia desde pequeno, busco resolver problemas de TI com qualquer ferramenta disponível, sem me limitar à minha stack atual ou minhas preferências (e considero desafiador).</p>
 

--- a/certif.html
+++ b/certif.html
@@ -33,9 +33,7 @@
 </header>
 <main>
   <div class="container">
-    <article class="card">
-      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
-      <p class="section-title" style="margin-top: 0;">Formação</p>
+    <article class="card">      <p class="section-title" style="margin-top: 0;">Formação</p>
       <h1>certif*</h1>
       <p class="time">Atualizado em 20 de julho de 2026</p>
       <p>Página destinada a listar minhas certificações e meus cursos (com e sem certificado).<br>

--- a/css/base.css
+++ b/css/base.css
@@ -224,37 +224,12 @@ main { padding: var(--space-6) 0; }
   main { animation: site-fade-in 0.4s ease; }
 }
 
-/* Cartao "blueprint": cantos tecnicos, sem sombra, radius zero. */
 .card {
-  position: relative;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: 0;
   padding: var(--space-6);
   margin-bottom: var(--space-6);
-}
-
-.corner {
-  position: absolute;
-  width: 5px;
-  height: 5px;
-  background: var(--color-bg);
-  border: 1px solid var(--color-accent);
-  z-index: 2;
-}
-.corner.tl { top: -3px; left: -3px; }
-.corner.tr { top: -3px; right: -3px; }
-.corner.bl { bottom: -3px; left: -3px; }
-.corner.br { bottom: -3px; right: -3px; }
-
-.avatar {
-  width: 84px;
-  height: 84px;
-  border-radius: 0;
-  object-fit: cover;
-  display: block;
-  flex: none;
-  box-shadow: var(--shadow-md);
 }
 
 /* Botoes: radius zero, peso 600, sem caixa-alta forcada (igual aos .btn da referencia). */
@@ -285,13 +260,6 @@ main { padding: var(--space-6) 0; }
   padding-bottom: var(--space-4);
 }
 
-.home-intro {
-  display: flex;
-  align-items: center;
-  gap: var(--space-4);
-  flex-wrap: wrap;
-}
-
 .home-subtitle {
   font-size: 1.0625rem;
   line-height: 1.55;
@@ -300,19 +268,15 @@ main { padding: var(--space-6) 0; }
   color: color-mix(in srgb, var(--color-text) 82%, transparent);
 }
 
-/* Eyebrow: badge em pilula, igual ao .home-eyebrow real da referencia. */
+/* Eyebrow: rotulo discreto, sem pilula nem fundo, so um respiro de cor. */
 .home-eyebrow {
-  display: inline-block;
+  display: block;
   font-family: var(--font-heading);
   font-weight: 600;
-  font-size: 0.8125rem;
-  letter-spacing: 0.1em;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--color-accent-emphasis);
-  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
-  border: 1px solid color-mix(in srgb, var(--color-accent) 15%, transparent);
-  border-radius: 99px;
-  padding: 0.375rem 1rem;
   margin: 0 0 var(--space-2);
 }
 
@@ -324,7 +288,6 @@ main { padding: var(--space-6) 0; }
 }
 
 .nav-card {
-  position: relative;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   padding: var(--space-6);

--- a/index.html
+++ b/index.html
@@ -32,33 +32,22 @@
 </header>
 <main>
   <div class="container home-hero">
-    <div class="home-intro">
-      <img class="avatar" src="/img/avatar.png" alt="Foto de Alan Nascimento">
-      <div>
-        <p class="home-eyebrow">Site pessoal e portfólio</p>
-        <h1 class="home-title">Alan Nascimento</h1>
-      </div>
-    </div>
+    <p class="home-eyebrow">Site pessoal e portfólio</p>
+    <h1 class="home-title">Alan Nascimento</h1>
     <p class="home-subtitle">Engenheiro de Dados no Bradesco, com trajetória em BI, automação e governança de dados.</p>
 
     <div class="nav-cards">
-      <a class="nav-card" href="/bio.html">
-        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
-        <span class="nav-card-kicker nav-card-kicker-accent">Trajetória</span>
+      <a class="nav-card" href="/bio.html">        <span class="nav-card-kicker nav-card-kicker-accent">Trajetória</span>
         <h2 class="nav-card-title">bio</h2>
         <p class="nav-card-desc">De atendimento ao cliente a Engenheiro de Dados: os 10 anos de carreira no Bradesco.</p>
         <span class="btn btn-primary">Ler a bio</span>
       </a>
-      <a class="nav-card" href="/certif.html">
-        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
-        <span class="nav-card-kicker">Formação</span>
+      <a class="nav-card" href="/certif.html">        <span class="nav-card-kicker">Formação</span>
         <h2 class="nav-card-title">certif*</h2>
         <p class="nav-card-desc">Certificações Microsoft, cursos concluídos e em andamento desde 2012.</p>
         <span class="btn btn-outline">Ver certificações</span>
       </a>
-      <a class="nav-card" href="/setup.html">
-        <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
-        <span class="nav-card-kicker">Bastidores</span>
+      <a class="nav-card" href="/setup.html">        <span class="nav-card-kicker">Bastidores</span>
         <h2 class="nav-card-title">setup</h2>
         <p class="nav-card-desc">Equipamentos e stack de software usados no dia a dia.</p>
         <span class="btn btn-outline">Ver setup</span>

--- a/setup.html
+++ b/setup.html
@@ -32,9 +32,7 @@
 </header>
 <main>
   <div class="container">
-    <article class="card">
-      <i class="corner tl"></i><i class="corner tr"></i><i class="corner bl"></i><i class="corner br"></i>
-      <p class="section-title" style="margin-top: 0;">Bastidores</p>
+    <article class="card">      <p class="section-title" style="margin-top: 0;">Bastidores</p>
       <h1>setup</h1>
       <p class="time">Espaço separado para listar meu setup e minha stack atuais.</p>
 


### PR DESCRIPTION
## Resumo
- Foto de perfil removida da home e da bio (avatar circular ja tinha virado quadrado no PR anterior; agora foi removida por completo, a pedido).
- Cantos tecnicos (.corner) removidos dos cards/nav-cards em todas as paginas: era o elemento mais chamativo/"gimmick" da identidade visual e destoava do pedido de site elegante, minimalista e discreto.
- Eyebrow (SITE PESSOAL E PORTFOLIO / TRAJETORIA etc.) deixou de ser uma pilula com fundo e borda: agora e so um rotulo pequeno em caixa alta, discreto.
- CSS morto removido (.avatar, .home-intro, .corner e position: relative que so servia para os corners).

## Test plan
- [x] Testado visualmente (index e bio) via iframe local: sem foto, sem corner brackets, layout sem buracos onde a foto estava
- [x] Confirmado que nenhuma tag ficou orfa apos remover os cantos (<i> abertos = fechados em todas as paginas)