### PR TITLE
polish(site): foco de teclado, reduced-motion e link do projeto

### DIFF
--- a/bio.html
+++ b/bio.html
@@ -64,7 +64,7 @@
 
       <div class="resume-cta">
         <p>Quer montar o seu currículo com o mesmo cuidado? Criei uma ferramenta gratuita para isso.</p>
-        <a class="btn btn-outline" href="https://github.com/eualannascimento/project-classificavagas-page-resume" target="_blank" rel="noopener noreferrer">Ver o projeto ↗</a>
+        <a class="btn btn-outline" href="https://classificavagas.com" target="_blank" rel="noopener noreferrer">Ver o projeto ↗</a>
       </div>
     </article>
   </div>

--- a/css/base.css
+++ b/css/base.css
@@ -149,6 +149,13 @@ h1 {
 a { color: var(--color-accent-emphasis); text-underline-offset: 3px; }
 a:hover { color: var(--color-accent); }
 
+/* Foco de teclado consistente em todos os interativos (links, botoes, cartoes). */
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
 .container {
   max-width: var(--max-width);
   margin: 0 auto;
@@ -222,6 +229,12 @@ main { padding: var(--space-6) 0; }
 }
 @media (prefers-reduced-motion: no-preference) {
   main { animation: site-fade-in 0.4s ease; }
+}
+
+/* Sem deslocamentos/transicoes de movimento quando o usuario pede menos animacao. */
+@media (prefers-reduced-motion: reduce) {
+  * { transition-duration: 0.001ms !important; }
+  .nav-card:hover { transform: none; }
 }
 
 .card {
@@ -306,7 +319,7 @@ main { padding: var(--space-6) 0; }
   font-size: 0.75rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-text) 55%, transparent);
+  color: color-mix(in srgb, var(--color-text) 68%, transparent);
 }
 .nav-card-kicker-accent { color: var(--color-accent-emphasis); }
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 
     <div class="resume-cta">
       <p>Também criei uma ferramenta gratuita para gerar currículo e guia de LinkedIn, sem cadastro e 100% no navegador.</p>
-      <a class="btn btn-outline" href="https://github.com/eualannascimento/project-classificavagas-page-resume" target="_blank" rel="noopener noreferrer">Ver o projeto ↗</a>
+      <a class="btn btn-outline" href="https://classificavagas.com" target="_blank" rel="noopener noreferrer">Ver o projeto ↗</a>
     </div>
   </div>
 </main>

--- a/tests/smoke-test.js
+++ b/tests/smoke-test.js
@@ -47,10 +47,16 @@ assert(baseCss.includes('--color-'), 'tokens de cor definidos em variaveis CSS')
 pages.forEach((page) => {
   const html = read(page);
   assert(html.includes('css/base.css'), `${page} referencia css/base.css`);
-  assert(/href="\/?bio\.html"/.test(html) && /href="\/?certif\.html"/.test(html) && /href="\/?setup\.html"/.test(html), `${page} tem navegacao para bio/certif/setup`);
-  assert(html.includes('github.com/eualannascimento') && html.includes('linkedin.com/in/eualannascimento'), `${page} tem links de GitHub e LinkedIn`);
-  assert(/href="https:\/\/github\.com\/eualannascimento"[^>]*target="_blank"/.test(html), `${page} abre link do GitHub em nova aba`);
+  assert(html.includes('<a class="brand" href="/">'), `${page} tem link de volta para a home (brand)`);
+  assert(html.includes('linkedin.com/in/eualannascimento'), `${page} tem link de LinkedIn`);
+  assert(/href="https:\/\/www\.linkedin\.com\/in\/eualannascimento"[^>]*target="_blank"/.test(html), `${page} abre o link do LinkedIn em nova aba`);
 });
+
+const homeHtml = read('index.html');
+assert(
+  /href="\/?bio\.html"/.test(homeHtml) && /href="\/?certif\.html"/.test(homeHtml) && /href="\/?setup\.html"/.test(homeHtml),
+  'index.html oferece navegacao para bio/certif/setup (nav-cards)'
+);
 
 // --- Regra 12: certif.html e setup.html consomem dados estruturados via JS ---
 console.log('\nDados estruturados (Regra 12):');


### PR DESCRIPTION
## Resumo
- Botao "Ver o projeto" (home e bio) agora aponta para classificavagas.com.
- Foco de teclado visivel e consistente (:focus-visible) em links, botoes e nav-cards, com a cor de acento ja usada no hover.
- prefers-reduced-motion: reduce neutraliza transicoes e o deslocamento no hover dos nav-cards.
- Contraste do nav-card-kicker aumentado (55% -> 68%).
- tests/smoke-test.js atualizado: as asserções de header (nav bio/certif/setup + GitHub) estavam presas ao layout anterior ao redesign do header (PRs #8/#9, ja mesclados). Passam a validar o link de volta pra home e o LinkedIn por pagina, e a navegacao para bio/certif/setup via nav-cards.

## Fora de escopo (nao alterado)
- Conteudo, rotas, fontes, paleta-base, dependencias, deploy.

## Test plan
- [x] node tests/smoke-test.js: 115 passou, 0 falhou
- [x] Sem overflow horizontal em index/bio/certif/setup, testado em 320/375/768/1024/1440px
- [x] Regra :focus-visible confirmada no CSSOM carregado